### PR TITLE
feat/#20 자전거 반납 메세지 리스너 구현 및 PaymentService 수정

### DIFF
--- a/pay/src/main/java/com/tukassemble/pay/domain/pay/controller/PaymentController.java
+++ b/pay/src/main/java/com/tukassemble/pay/domain/pay/controller/PaymentController.java
@@ -3,6 +3,7 @@ package com.tukassemble.pay.domain.pay.controller;
 import com.tukassemble.pay.domain.pay.domain.entity.Payment;
 import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
 import com.tukassemble.pay.domain.pay.service.PaymentService;
+import javax.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,8 +11,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)

--- a/pay/src/main/java/com/tukassemble/pay/domain/pay/controller/PaymentController.java
+++ b/pay/src/main/java/com/tukassemble/pay/domain/pay/controller/PaymentController.java
@@ -1,10 +1,17 @@
 package com.tukassemble.pay.domain.pay.controller;
 
+import com.tukassemble.pay.domain.pay.domain.entity.Payment;
+import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
 import com.tukassemble.pay.domain.pay.service.PaymentService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -12,9 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class PaymentController {
   private final PaymentService paymentService;
 
-  //  @PostMapping
-  //  public ResponseEntity<PaymentResult> pay(@Valid @RequestBody PaymentRequest paymentRequest) {
-  //    PaymentResult paymentResult = paymentService.pay(paymentRequest);
-  //    return ResponseEntity.ok(paymentResult);
-  //  }
+  // pay 의 기능을 임시로 사용 해보기 위한 API
+  @PostMapping
+  public ResponseEntity<Payment> pay(@Valid @RequestBody PaymentMessage paymentMessage) {
+    Payment paymentResult = paymentService.pay(paymentMessage);
+    return ResponseEntity.ok(paymentResult);
+  }
 }

--- a/pay/src/main/java/com/tukassemble/pay/domain/pay/dto/PaymentMessage.java
+++ b/pay/src/main/java/com/tukassemble/pay/domain/pay/dto/PaymentMessage.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class PaymentRequest {
+public class PaymentMessage {
   @NotNull(message = "대여 ID는 필수 입력값 입니다.")
   private Long rentalId;
 

--- a/pay/src/main/java/com/tukassemble/pay/domain/pay/mapper/PaymentMapper.java
+++ b/pay/src/main/java/com/tukassemble/pay/domain/pay/mapper/PaymentMapper.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentMapper {
   public Payment toEntity(
-          PaymentMessage paymentRequest, Integer payAmount, Integer point, Boolean isPaid) {
+      PaymentMessage paymentRequest, Integer payAmount, Integer point, Boolean isPaid) {
     return Payment.builder()
         .rentalId(paymentRequest.getRentalId())
         .userId(paymentRequest.getUserId())

--- a/pay/src/main/java/com/tukassemble/pay/domain/pay/mapper/PaymentMapper.java
+++ b/pay/src/main/java/com/tukassemble/pay/domain/pay/mapper/PaymentMapper.java
@@ -1,7 +1,7 @@
 package com.tukassemble.pay.domain.pay.mapper;
 
 import com.tukassemble.pay.domain.pay.domain.entity.Payment;
-import com.tukassemble.pay.domain.pay.dto.PaymentRequest;
+import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentMapper {
   public Payment toEntity(
-      PaymentRequest paymentRequest, Integer payAmount, Integer point, Boolean isPaid) {
+          PaymentMessage paymentRequest, Integer payAmount, Integer point, Boolean isPaid) {
     return Payment.builder()
         .rentalId(paymentRequest.getRentalId())
         .userId(paymentRequest.getUserId())

--- a/pay/src/main/java/com/tukassemble/pay/domain/pay/service/KafkaConsumerService.java
+++ b/pay/src/main/java/com/tukassemble/pay/domain/pay/service/KafkaConsumerService.java
@@ -1,0 +1,27 @@
+package com.tukassemble.pay.domain.pay.service;
+
+import com.tukassemble.pay.domain.pay.domain.entity.Payment;
+import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaConsumerService {
+    private final PaymentService paymentService;
+
+    @KafkaListener(
+            groupId = "${spring.kafka.consumer.group-id}",
+            topics = "${spring.kafka.topic.name}"
+    )
+    public void pay(PaymentMessage paymentMessage) {
+        Payment paymentResult = paymentService.pay(paymentMessage);
+        if(paymentResult.getIsPaid()) {
+            // point 적립 message pub
+            // kafkaProducerService.sendMessage(POINT_EARN_TOPIC, pointMessage);
+        }
+    }
+}

--- a/pay/src/main/java/com/tukassemble/pay/domain/pay/service/KafkaConsumerService.java
+++ b/pay/src/main/java/com/tukassemble/pay/domain/pay/service/KafkaConsumerService.java
@@ -19,8 +19,9 @@ public class KafkaConsumerService {
   public void pay(PaymentMessage paymentMessage) {
     Payment paymentResult = paymentService.pay(paymentMessage);
     if (paymentResult.getIsPaid()) {
-      // point 적립 message pub
+      // point 적립 message pub 넣기
       // kafkaProducerService.sendMessage(POINT_EARN_TOPIC, pointMessage);
+      log.info("point earn message pub");
     }
   }
 }

--- a/pay/src/main/java/com/tukassemble/pay/domain/pay/service/KafkaConsumerService.java
+++ b/pay/src/main/java/com/tukassemble/pay/domain/pay/service/KafkaConsumerService.java
@@ -11,17 +11,16 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class KafkaConsumerService {
-    private final PaymentService paymentService;
+  private final PaymentService paymentService;
 
-    @KafkaListener(
-            groupId = "${spring.kafka.consumer.group-id}",
-            topics = "${spring.kafka.topic.name}"
-    )
-    public void pay(PaymentMessage paymentMessage) {
-        Payment paymentResult = paymentService.pay(paymentMessage);
-        if(paymentResult.getIsPaid()) {
-            // point 적립 message pub
-            // kafkaProducerService.sendMessage(POINT_EARN_TOPIC, pointMessage);
-        }
+  @KafkaListener(
+      groupId = "${spring.kafka.consumer.group-id}",
+      topics = "${spring.kafka.topic.name}")
+  public void pay(PaymentMessage paymentMessage) {
+    Payment paymentResult = paymentService.pay(paymentMessage);
+    if (paymentResult.getIsPaid()) {
+      // point 적립 message pub
+      // kafkaProducerService.sendMessage(POINT_EARN_TOPIC, pointMessage);
     }
+  }
 }

--- a/pay/src/main/java/com/tukassemble/pay/domain/pay/service/PaymentService.java
+++ b/pay/src/main/java/com/tukassemble/pay/domain/pay/service/PaymentService.java
@@ -6,7 +6,6 @@ import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
 import com.tukassemble.pay.domain.pay.mapper.PaymentMapper;
 import java.time.Duration;
 import java.time.LocalDateTime;
-
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/pay/src/main/java/com/tukassemble/pay/global/config/KafkaConfigConsumer.java
+++ b/pay/src/main/java/com/tukassemble/pay/global/config/KafkaConfigConsumer.java
@@ -1,6 +1,8 @@
 package com.tukassemble.pay.global.config;
 
 import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,9 +11,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Configuration
 public class KafkaConfigConsumer {

--- a/pay/src/main/java/com/tukassemble/pay/global/config/KafkaConfigConsumer.java
+++ b/pay/src/main/java/com/tukassemble/pay/global/config/KafkaConfigConsumer.java
@@ -1,8 +1,9 @@
 package com.tukassemble.pay.global.config;
 
-import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 @Configuration
@@ -21,13 +23,21 @@ public class KafkaConfigConsumer {
   private String consumerGroupId;
 
   @Bean
-  public ConsumerFactory<String, PaymentMessage> consumerFactory() {
+  public Map<String, Object> consumerConfig() {
     Map<String, Object> properties = new HashMap<>();
     properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, consumerBootstrapServers);
     properties.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupId);
-    properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-    return new DefaultKafkaConsumerFactory<>(properties);
+    properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+    properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+    return properties;
+  }
+
+  @Bean
+  public ConsumerFactory<String, PaymentMessage> consumerFactory() {
+    return new DefaultKafkaConsumerFactory<>(
+        consumerConfig(),
+        new ErrorHandlingDeserializer<>(new StringDeserializer()),
+        new ErrorHandlingDeserializer<>(new JsonDeserializer<>(PaymentMessage.class)));
   }
 
   @Bean

--- a/pay/src/main/java/com/tukassemble/pay/global/config/KafkaConfigConsumer.java
+++ b/pay/src/main/java/com/tukassemble/pay/global/config/KafkaConfigConsumer.java
@@ -1,9 +1,8 @@
 package com.tukassemble.pay.global.config;
 
+import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;

--- a/pay/src/main/java/com/tukassemble/pay/global/config/KafkaConfigConsumer.java
+++ b/pay/src/main/java/com/tukassemble/pay/global/config/KafkaConfigConsumer.java
@@ -1,0 +1,42 @@
+package com.tukassemble.pay.global.config;
+
+import com.tukassemble.pay.domain.pay.dto.PaymentMessage;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfigConsumer {
+  @Value("${spring.kafka.consumer.bootstrap-servers}")
+  private String consumerBootstrapServers;
+
+  @Value("${spring.kafka.consumer.group-id}")
+  private String consumerGroupId;
+
+  @Bean
+  public ConsumerFactory<String, PaymentMessage> consumerFactory() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, consumerBootstrapServers);
+    properties.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupId);
+    properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    return new DefaultKafkaConsumerFactory<>(properties);
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, PaymentMessage>
+      kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, PaymentMessage> kafkaListenerContainerFactory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    kafkaListenerContainerFactory.setConsumerFactory(consumerFactory());
+    return kafkaListenerContainerFactory;
+  }
+}

--- a/pay/src/main/resources/application.yml
+++ b/pay/src/main/resources/application.yml
@@ -23,3 +23,8 @@ spring:
   kafka:
     producer:
       bootstrap-servers: localhost:9092
+    consumer:
+      bootstrap-servers: localhost:9092
+      group-id: "returnedGroupId"
+    topic:
+      name: "returned"


### PR DESCRIPTION
자전거 반납시 returned topic으로 아래 형식으로 메세지 날릴 시 pay메소드 실행
{"rentalId":3,"userId":3,"bikeId":9,"rentaledAt":"2023-02-04T05:10:11.156Z","returnedAt":"2023-02-04T05:15:11.156Z"}

실제 kafka console에서 테스트 한 모습
<img width="646" alt="image" src="https://user-images.githubusercontent.com/108508730/216756032-c177a9e9-c216-449f-a8bc-8cb8d49f7b37.png">
<img width="542" alt="image" src="https://user-images.githubusercontent.com/108508730/216756075-a98004bb-3750-4981-a600-d4ddc8c63922.png">
<img width="721" alt="image" src="https://user-images.githubusercontent.com/108508730/216756295-0b343dfe-45a3-460f-a35d-5d68234935c3.png">

형식이 다르면 ListenerExecutionFailedException 발생